### PR TITLE
Adding statusinfo class for OneRoster 1.2 imsx_statusInfo support

### DIFF
--- a/classes/statusinfo.php
+++ b/classes/statusinfo.php
@@ -1,0 +1,27 @@
+<?php
+namespace enrol_oneroster;
+
+defined('MOODLE_INTERNAL') || die();
+
+class statusinfo {
+    public $codeMajor;
+    public $severity;
+    public $codeMinor;
+    public $description;
+
+    public function __construct($data) {
+        $this->codeMajor = $data['codeMajor'] ?? 'failure';
+        $this->severity = $data['severity'] ?? 'error';
+        $this->codeMinor = $data['codeMinor'] ?? '';
+        $this->description = $data['description'] ?? '';
+    }
+
+    public function to_array() {
+        return [
+            'imsx_codeMajor' => $this->codeMajor,
+            'imsx_severity' => $this->severity,
+            'imsx_codeMinor' => ['code' => $this->codeMinor],
+            'imsx_description' => ['text' => $this->description]
+        ];
+    }
+}


### PR DESCRIPTION
In this draft PR, the statusinfo class was created to match the imsx_statusInfo schema required by OneRoster 1.2.

Here, we focus on codeMajor, severity, codeMinor and description.
Uses a to_array() method to help formatting the status info response.
I am looking for your feedback or suggestions before checking it as ready to be reviewed.
